### PR TITLE
Port changes from 17.03 compatibility branch to 18.03

### DIFF
--- a/adho-configuration.nix
+++ b/adho-configuration.nix
@@ -54,6 +54,12 @@
         psk = "sarabar1989";
       };
 
+      # The Dubliner
+      "DubGjest" = {
+        # of course
+        psk = "Guinness";
+      };
+
       # Sync Compound
       "RWDS" = {
         psk = "radicalagenda";

--- a/configuration.nix
+++ b/configuration.nix
@@ -49,6 +49,8 @@
     ssh.startAgent = true;
   };
 
+  services.postgresql.enable = true;
+
   # Configure user account
   users.defaultUserShell = pkgs.fish;
   users.extraUsers.vincent = {

--- a/desktop.nix
+++ b/desktop.nix
@@ -3,6 +3,9 @@
 { config, lib, pkgs, ... }:
 
 let emacs = import ./emacs.nix { inherit pkgs; };
+screenLock = pkgs.writeShellScriptBin "screen-lock" ''
+  find ${pkgs.wallpapers} -name "*.png" | shuf -n1 | xargs i3lock -f -t -i
+'';
 in {
   # Configure basic X-server stuff:
   services.xserver = {
@@ -14,6 +17,8 @@ in {
     displayManager.sessionCommands = "${pkgs.xorg.xhost}/bin/xhost +SI:localuser:$USER";
   };
 
+  # Add a shell script with random screen lock wallpaper selection
+  environment.systemPackages = [ screenLock ];
 
   # Apparently when you have house guests they complain about your screen tearing!
   services.compton.enable = true;


### PR DESCRIPTION
adho is still running 17.03 and some changes have been made in the meantime. This moves them over into the (18.03) master.